### PR TITLE
Ensure co-author works in any GIT_COMMIT_MSG buffer

### DIFF
--- a/lua/co-author/init.lua
+++ b/lua/co-author/init.lua
@@ -22,9 +22,7 @@ co_author.list = function()
         vim.ui.select(items, { prompt = 'Select Co-Author' }, function(item, _)
             if item ~= nil then
                 local string = 'Co-authored-by: ' .. item
-                local cursor_position = vim.api.nvim_win_get_cursor(0)
-                local line = cursor_position[1] + 1
-                local column = cursor_position[2]
+                local line, column = unpack(vim.api.nvim_win_get_cursor(0))
 
                 vim.api.nvim_buf_set_lines(0, line, line, true, { string })
                 vim.api.nvim_win_set_cursor(0, { line, column + #string })


### PR DESCRIPTION
## What/How/Why

Fixes: https://github.com/2KAbhishek/co-author.nvim/issues/5

Before it was trying to add the text outside of the buffer when the GIT_COMMIT_MSG buffer was invoked by lazygit. The buffer looks a bit different for some reason but it's still a GIT_COMMIT_MSG buffer.

This way the string is added right on top of the line you're currently located and it works either on a buffer created by git commit or the lazygit one.

## Screenshots

### LazyGit

Selecting co-author for commit
![Screenshot 2024-05-01 at 16 16 00](https://github.com/2KAbhishek/co-author.nvim/assets/5471469/c7c56c61-ecb8-4465-9a7a-4453e8aa84b9)

The author is added below the current line
![Screenshot 2024-05-01 at 16 16 04](https://github.com/2KAbhishek/co-author.nvim/assets/5471469/ffc1e90d-f475-416a-b9fe-1965652f4f66)

### git commit

Selecting co-author for commit
![Screenshot 2024-05-01 at 16 16 18](https://github.com/2KAbhishek/co-author.nvim/assets/5471469/3f52d351-7b98-452c-97d5-de917d2bce33)

The author is added below the current line

![Screenshot 2024-05-01 at 16 16 21](https://github.com/2KAbhishek/co-author.nvim/assets/5471469/a435c78e-9857-4c0d-96c3-0df41e4b6b6e)


