### PR TITLE
fix: restrict git log output

### DIFF
--- a/lua/co-author/init.lua
+++ b/lua/co-author/init.lua
@@ -1,7 +1,7 @@
 local co_author = {}
 
 co_author.generate = function()
-    local co_authors = vim.fn.systemlist('git log --format="%aN <%aE>"')
+    local co_authors = vim.fn.systemlist('git -c log.showSignature=false log --format="%aN <%aE>"')
     local unique_co_authors = {}
     for _, author in ipairs(co_authors) do
         if not unique_co_authors[author] then


### PR DESCRIPTION
## What

What does this pull request accomplish?

- [x] restrict log output from showing signatures

## How

What code changes were made to accomplish it?

- Modify the git log command to ensure `log.showSignature = false` while running Co-Author

## Why

- [x] this fixes the issue where Co-Author menu is filled with commit signature checks

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
